### PR TITLE
feat: import spotify playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ npm run electron-pack
 - **🔄 Background Playback**: Continue listening while using other apps
 - **🚫 No Login Required**: Jump right in! No accounts or sign-ups needed
 - **💾 Persistent State**: Your liked songs and recently played tracks are saved across app restarts
+- **📥 Spotify Playlist Import**: Bring in tracks from any Spotify playlist using your own API token
 - **🎨 Beautiful UI**: Clean, modern interface designed for each platform
 - **🆓 Completely Free & Ad-Free**: Enjoy uninterrupted music without any cost or advertisements
 

--- a/openspot-mobile/app/(tabs)/library.tsx
+++ b/openspot-mobile/app/(tabs)/library.tsx
@@ -10,6 +10,7 @@ import { MusicPlayerContext } from './_layout';
 import { Ionicons } from '@expo/vector-icons';
 import { PlaylistStorage, Playlist } from '@/lib/playlist-storage';
 import { MusicAPI } from '@/lib/music-api';
+import { importSpotifyPlaylist } from '@/lib/spotify-import';
 import { useFocusEffect } from 'expo-router';
 
 export default function LibraryScreen() {
@@ -26,6 +27,8 @@ export default function LibraryScreen() {
   const [selectedPlaylist, setSelectedPlaylist] = useState<Playlist | null>(null);
   const [playlistTracks, setPlaylistTracks] = useState<any[]>([]);
   const [showLikedSongs, setShowLikedSongs] = useState(false);
+  const [showImportModal, setShowImportModal] = useState(false);
+  const [spotifyUrl, setSpotifyUrl] = useState('');
 
   useEffect(() => {
     fetchPlaylists();
@@ -270,6 +273,10 @@ export default function LibraryScreen() {
             <Ionicons name="add-circle" size={24} color="#1DB954" style={{ marginRight: 8 }} />
             <Text style={styles.createButtonText}>Create Playlist</Text>
           </TouchableOpacity>
+          <TouchableOpacity style={styles.createButton} onPress={() => setShowImportModal(true)}>
+            <Ionicons name="logo-spotify" size={24} color="#1DB954" style={{ marginRight: 8 }} />
+            <Text style={styles.createButtonText}>Import Spotify Playlist</Text>
+          </TouchableOpacity>
           <View style={{ height: 120 }} />
         </ScrollView>
       ) : (
@@ -359,6 +366,39 @@ export default function LibraryScreen() {
               <Text style={styles.createButtonText}>Create</Text>
             </TouchableOpacity>
             <TouchableOpacity style={styles.cancelButton} onPress={() => setShowCreateModal(false)}>
+              <Text style={{ color: '#fff', fontSize: 15 }}>Cancel</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
+      <Modal visible={showImportModal} transparent animationType="fade" onRequestClose={() => setShowImportModal(false)}>
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalBox}>
+            <Text style={styles.modalTitle}>Import Spotify Playlist</Text>
+            <TextInput
+              style={styles.input}
+              placeholder="Playlist URL or ID"
+              placeholderTextColor="#888"
+              value={spotifyUrl}
+              onChangeText={setSpotifyUrl}
+            />
+            <TouchableOpacity
+              style={[styles.createButton, { marginTop: 18 }]}
+              onPress={async () => {
+                try {
+                  await importSpotifyPlaylist(spotifyUrl.trim());
+                  setShowImportModal(false);
+                  setSpotifyUrl('');
+                  fetchPlaylists();
+                } catch (e) {
+                  Alert.alert('Import failed', (e as Error).message);
+                }
+              }}
+            >
+              <Ionicons name="logo-spotify" size={24} color="#1DB954" style={{ marginRight: 8 }} />
+              <Text style={styles.createButtonText}>Import</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.cancelButton} onPress={() => setShowImportModal(false)}>
               <Text style={{ color: '#fff', fontSize: 15 }}>Cancel</Text>
             </TouchableOpacity>
           </View>

--- a/openspot-mobile/lib/spotify-import.ts
+++ b/openspot-mobile/lib/spotify-import.ts
@@ -1,0 +1,54 @@
+import axios from 'axios';
+import { PlaylistStorage, Playlist } from './playlist-storage';
+import { MusicAPI } from './music-api';
+
+interface SpotifyPlaylistResponse {
+  name: string;
+  images: { url: string }[];
+  tracks: {
+    items: {
+      track: {
+        name: string;
+        artists: { name: string }[];
+      };
+    }[];
+  };
+}
+
+function extractPlaylistId(input: string): string {
+  const match = input.match(/playlist\/(\w+)|([a-zA-Z0-9]{22})/);
+  if (!match) throw new Error('Invalid playlist URL or ID');
+  return match[1] || match[2];
+}
+
+export async function importSpotifyPlaylist(playlistUrl: string): Promise<void> {
+  const token = process.env.EXPO_PUBLIC_SPOTIFY_TOKEN;
+  if (!token) throw new Error('Spotify token not configured');
+
+  const playlistId = extractPlaylistId(playlistUrl);
+  const { data } = await axios.get<SpotifyPlaylistResponse>(`https://api.spotify.com/v1/playlists/${playlistId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  const trackIds: string[] = [];
+  for (const item of data.tracks.items) {
+    const title = item.track.name;
+    const artist = item.track.artists[0]?.name ?? '';
+    try {
+      const res = await MusicAPI.search({ q: `${title} ${artist}`, type: 'track' });
+      if (res.tracks && res.tracks.length > 0) {
+        trackIds.push(res.tracks[0].id.toString());
+      }
+    } catch {
+      // Ignore individual track errors
+    }
+  }
+
+  const playlist: Playlist = {
+    name: data.name,
+    cover: data.images?.[0]?.url || '',
+    trackIds,
+  };
+
+  await PlaylistStorage.addPlaylist(playlist);
+}


### PR DESCRIPTION
## Summary
- enable importing Spotify playlists in mobile library
- add Spotify playlist importer module
- document playlist import capability

## Testing
- `npm test -- --watchAll=false` (fails: No tests found)
- `yarn lint` (fails: 3 errors, 54 warnings)


------
https://chatgpt.com/codex/tasks/task_e_6892200f13f8832b9c99430f2856c1af